### PR TITLE
[cmake] Fix cmake error on old cmake version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ project(dingo C CXX)
 option(EXAMPLE_LINK_SO "Whether examples are linked dynamically" OFF)
 option(LINK_TCMALLOC "Link tcmalloc if possible" OFF)
 
+# Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+    cmake_policy(SET CMP0135 NEW)
+endif()
+
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(THIRD_PARTY_PATH ${CMAKE_CURRENT_BINARY_DIR}/third-party)
 

--- a/cmake/braft.cmake
+++ b/cmake/braft.cmake
@@ -30,7 +30,6 @@ ExternalProject_Add(
 #        GIT_TAG "v1.1.1"
         # URL "https://github.com/baidu/braft/archive/v1.1.1.tar.gz"
         URL "https://github.com/baidu/braft/archive/master.tar.gz"
-        DOWNLOAD_EXTRACT_TIMESTAMP ON
         PREFIX ${BRAFT_SOURCES_DIR}
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}

--- a/cmake/brpc.cmake
+++ b/cmake/brpc.cmake
@@ -30,7 +30,6 @@ ExternalProject_Add(
 #        GIT_REPOSITORY "https://github.com/apache/brpc"
 #        GIT_TAG "1.3.0"
         URL "https://github.com/apache/brpc/archive/1.3.0.tar.gz"
-        DOWNLOAD_EXTRACT_TIMESTAMP ON
         PREFIX ${BRPC_SOURCES_DIR}
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}

--- a/cmake/gflags.cmake
+++ b/cmake/gflags.cmake
@@ -29,7 +29,6 @@ ExternalProject_Add(
         extern_gflags
         ${EXTERNAL_PROJECT_LOG_ARGS}
         GIT_REPOSITORY "https://github.com/gflags/gflags.git"
-        DOWNLOAD_EXTRACT_TIMESTAMP ON
         GIT_TAG "v2.2.2"
         PREFIX ${GFLAGS_SOURCES_DIR}
         BUILD_COMMAND ${BUILD_COMMAND}

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -137,7 +137,6 @@ FUNCTION(build_protobuf TARGET_NAME)
             URL "https://github.com/protocolbuffers/protobuf/archive/v3.6.1.tar.gz"
             CONFIGURE_COMMAND mv ../config.sh . COMMAND sh config.sh
             CMAKE_CACHE_ARGS
-            DOWNLOAD_EXTRACT_TIMESTAMP ON
             -DCMAKE_INSTALL_PREFIX:PATH=${PROTOBUF_INSTALL_DIR}
             -DCMAKE_BUILD_TYPE:STRING=${THIRD_PARTY_BUILD_TYPE}
             -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF

--- a/cmake/rocksdb.cmake
+++ b/cmake/rocksdb.cmake
@@ -33,7 +33,6 @@ ExternalProject_Add(
 #        GIT_REPOSITORY "https://github.com/facebook/rocksdb.git"
 #        GIT_TAG "v7.8.3"
         URL "https://github.com/facebook/rocksdb/archive/v7.8.3.tar.gz"
-        DOWNLOAD_EXTRACT_TIMESTAMP ON
         UPDATE_COMMAND ""
 #        CONFIGURE_COMMAND ""
 #        BUILD_IN_SOURCE 1


### PR DESCRIPTION
The option DOWNLOAD_EXTRACT_TIMESTAMP cannot work correctly on old cmake version.
Add cmake version check for policy CMP0135 to fix this problem.

Signed-off-by: Ketor <d.ketor@gmail.com>