### PR TITLE
[cmake] Use dingo's internal OpenSSL.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "contrib/zlib"]
 	path = contrib/zlib
 	url = https://github.com/madler/zlib
+[submodule "contrib/openssl"]
+	path = contrib/openssl
+	url = https://github.com/openssl/openssl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,37 +19,9 @@ set(THIRD_PARTY_PATH ${CMAKE_CURRENT_BINARY_DIR}/third-party)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_PREFIX_PATH ${OUTPUT_PATH})
 
-# On macOS, search Homebrew for keg-only versions of OpenSSL
-# equivalent of # -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/ -DOPENSSL_CRYPTO_LIBRARY=/usr/local/opt/openssl/lib/
-if (CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
-    execute_process(
-        COMMAND brew --prefix OpenSSL
-        RESULT_VARIABLE BREW_OPENSSL
-        OUTPUT_VARIABLE BREW_OPENSSL_PREFIX
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-    if (BREW_OPENSSL EQUAL 0 AND EXISTS "${BREW_OPENSSL_PREFIX}")
-        message(STATUS "Found OpenSSL keg installed by Homebrew at ${BREW_OPENSSL_PREFIX}")
-        set(OPENSSL_ROOT_DIR "${BREW_OPENSSL_PREFIX}/")
-        set(OPENSSL_INCLUDE_DIR "${BREW_OPENSSL_PREFIX}/include")
-        set(OPENSSL_LIBRARIES "${BREW_OPENSSL_PREFIX}/lib")
-        set(OPENSSL_CRYPTO_LIBRARY "${BREW_OPENSSL_PREFIX}/lib/libcrypto.dylib")
-    endif()
-endif()
-
-#include(FindThreads)
-find_package(OpenSSL REQUIRED)
 find_package(Threads REQUIRED)
-# if (OPENSSL_FOUND)
-#   # Add the include directories for compiling
-#   target_include_directories(${TARGET_SERVER} PUBLIC ${OPENSSL_INCLUDE_DIR})
-#   # Add the static lib for linking
-#   target_link_libraries(${TARGET_SERVER} OpenSSL::SSL OpenSSL::Crypto)
-#   message(STATUS "Found OpenSSL ${OPENSSL_VERSION}")
-# else()
-#   message(STATUS "OpenSSL Not Found")
-# endif()
 
+include(openssl)
 include(zlib)
 include(gflags)
 include(glog)
@@ -61,10 +33,6 @@ include(rocksdb)
 include(brpc)
 include(braft)
 include(yaml-cpp)
-
-include_directories(
-        ${OPENSSL_INCLUDE_DIR}
-        )
 
 # LIST ALL THE PROTO FILES AND COMPILE IT TO .H AND .CPP
 file(GLOB PROTO_FILES ${CMAKE_SOURCE_DIR}/proto/*.proto)
@@ -97,6 +65,7 @@ include_directories(${GTEST_INCLUDE_DIR})
 include_directories(${GFLAGS_INCLUDE_DIR})
 include_directories(${ROCKSDB_INCLUDE_DIR})
 include_directories(${YAMLCPP_INCLUDE_DIR})
+include_directories(${OPENSSL_INCLUDE_DIR})
 include_directories(${PROJECT_SOURCE_DIR}/src)
 
 message(STATUS "===GTEST_LIBRARIES: ${GTEST_LIBRARIES}")
@@ -110,16 +79,18 @@ set(DYNAMIC_LIB
     ${ROCKSDB_LIBRARIES}
     ${SNAPPY_LIBRARIES}
     ${YAMLCPP_LIBRARIES}
-    rt
-    ssl
-    crypto
-    glog
+    ${ZLIB_LIBRARIES}
+    ${OPENSSL_LIBRARIES}
+    ${CRYPTO_LIBRARIES}
+    ${GLOG_LIBRARIES}
+    # rt
     dl
-    z
     Threads::Threads
     )
 
 set(DEPEND_LIBS
+    openssl
+    zlib
     gflags
     protobuf
     leveldb

--- a/cmake/openssl.cmake
+++ b/cmake/openssl.cmake
@@ -1,0 +1,42 @@
+# Copyright (c) 2023 dingodb.com, Inc. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+INCLUDE(ExternalProject)
+
+SET(OPENSSL_SOURCES_DIR ${THIRD_PARTY_PATH}/openssl)
+SET(OPENSSL_INSTALL_DIR ${THIRD_PARTY_PATH}/install/openssl)
+SET(OPENSSL_INCLUDE_DIR "${OPENSSL_INSTALL_DIR}/include" CACHE PATH "openssl include directory." FORCE)
+SET(OPENSSL_LIBRARIES "${OPENSSL_INSTALL_DIR}/lib/libssl.a" CACHE FILEPATH "openssl library." FORCE)
+SET(CRYPTO_LIBRARIES  "${OPENSSL_INSTALL_DIR}/lib/libcrypto.a" CACHE FILEPATH "openssl library." FORCE)
+
+FILE(WRITE ${OPENSSL_SOURCES_DIR}/src/copy_repo.sh
+        "mkdir -p ${OPENSSL_SOURCES_DIR}/src/extern_openssl/ && cp -rf ${CMAKE_SOURCE_DIR}/contrib/openssl/* ${OPENSSL_SOURCES_DIR}/src/extern_openssl/")
+
+execute_process(COMMAND sh ${OPENSSL_SOURCES_DIR}/src/copy_repo.sh)
+
+ExternalProject_Add(
+        extern_openssl
+        ${EXTERNAL_PROJECT_LOG_ARGS}
+        PREFIX ${OPENSSL_SOURCES_DIR}
+        UPDATE_COMMAND ""
+        SOURCE_DIR ${OPENSSL_SOURCES_DIR}/src/extern_openssl/
+        CONFIGURE_COMMAND sh config -DOPENSSL_NO_SCTP -DOPENSSL_NO_KTLS  -DOPENSSL_USE_NODELETE -DOPENSSL_PIC -no-shared
+        BUILD_IN_SOURCE 1
+        BUILD_COMMAND $(MAKE) -j ${NUM_OF_PROCESSOR}
+        INSTALL_COMMAND mkdir -p ${OPENSSL_INSTALL_DIR}/lib/ COMMAND cp ${OPENSSL_SOURCES_DIR}/src/extern_openssl/libssl.a ${OPENSSL_INSTALL_DIR}/lib/ COMMAND cp ${OPENSSL_SOURCES_DIR}/src/extern_openssl/libcrypto.a ${OPENSSL_INSTALL_DIR}/lib/ COMMAND cp -r ${OPENSSL_SOURCES_DIR}/src/extern_openssl/include ${OPENSSL_INSTALL_DIR}/
+)
+
+ADD_LIBRARY(openssl STATIC IMPORTED GLOBAL)
+SET_PROPERTY(TARGET openssl PROPERTY IMPORTED_LOCATION ${OPENSSL_LIBRARIES} ${CRYPTO_LIBRARIES})
+ADD_DEPENDENCIES(openssl extern_openssl)


### PR DESCRIPTION
Remove dependence to system OpenSSL and zlib.

Now we dingo-poc only depend on such libraries:
libdl.so.2
libpthread.so.0
libstdc++.so.6
libm.so.6
libgcc_s.so.1
libc.so.6