### PR TITLE
[cmake] Bump up OpenSSL version to 3.0.8.

### DIFF
--- a/cmake/brpc.cmake
+++ b/cmake/brpc.cmake
@@ -21,7 +21,7 @@ SET(BRPC_INCLUDE_DIR "${BRPC_INSTALL_DIR}/include" CACHE PATH "brpc include dire
 SET(BRPC_LIBRARIES "${BRPC_INSTALL_DIR}/lib/libbrpc.a" CACHE FILEPATH "brpc library." FORCE)
 
 # Reference https://stackoverflow.com/questions/45414507/pass-a-list-of-prefix-paths-to-externalproject-add-in-cmake-args
-set(prefix_path "${THIRD_PARTY_PATH}/install/gflags|${THIRD_PARTY_PATH}/install/protobuf|${THIRD_PARTY_PATH}/install/zlib|${THIRD_PARTY_PATH}/install/glog|${THIRD_PARTY_PATH}/install/leveldb")
+set(prefix_path "${THIRD_PARTY_PATH}/install/gflags|${THIRD_PARTY_PATH}/install/openssl|${THIRD_PARTY_PATH}/install/protobuf|${THIRD_PARTY_PATH}/install/zlib|${THIRD_PARTY_PATH}/install/glog|${THIRD_PARTY_PATH}/install/leveldb")
 
 # If minimal .a is need, you can set  WITH_DEBUG_SYMBOLS=OFF
 ExternalProject_Add(
@@ -57,7 +57,7 @@ ExternalProject_Add(
         INSTALL_COMMAND mkdir -p ${BRPC_INSTALL_DIR}/lib/ COMMAND cp ${BRPC_BINARY_DIR}/output/lib/libbrpc.a ${BRPC_LIBRARIES} COMMAND cp -r ${BRPC_BINARY_DIR}/output/include ${BRPC_INCLUDE_DIR}/
 )
 # ADD_DEPENDENCIES(extern_brpc ssl crypto zlib protobuf leveldb gflags glog)
-ADD_DEPENDENCIES(extern_brpc zlib protobuf leveldb gflags glog)
+ADD_DEPENDENCIES(extern_brpc zlib protobuf leveldb gflags glog openssl)
 ADD_LIBRARY(brpc STATIC IMPORTED GLOBAL)
 SET_PROPERTY(TARGET brpc PROPERTY IMPORTED_LOCATION ${BRPC_LIBRARIES})
 ADD_DEPENDENCIES(brpc extern_brpc)


### PR DESCRIPTION
Update brpc.cmake to support internal openssl version.

Bump up OpenSSL version to 3.0.8.
