### PR TITLE
[cmake] Fix compile erro on CentOS 7.

### DIFF
--- a/src/coordinator/coordinator_control.cc
+++ b/src/coordinator/coordinator_control.cc
@@ -14,7 +14,6 @@
 
 #include "coordinator/coordinator_control.h"
 
-#include <bits/types/FILE.h>
 #include <sys/types.h>
 
 #include <cstdint>


### PR DESCRIPTION
[cmake] Fix compile erro on CentOS 7.
FILE.h is not needed in dingo-poc.