### PR TITLE
[coordinator] Implement GetCoordinatorMap rpc call.

### DIFF
--- a/src/client/coordinator_client.cc
+++ b/src/client/coordinator_client.cc
@@ -101,6 +101,27 @@ void SendGetStoreMap(brpc::Controller& cntl, dingodb::pb::coordinator::Coordinat
   }
 }
 
+void SendGetCoordinatorMap(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
+  dingodb::pb::coordinator::GetCoordinatorMapRequest request;
+  dingodb::pb::coordinator::GetCoordinatorMapResponse response;
+
+  request.set_cluster_id(0);
+
+  stub.GetCoordinatorMap(&cntl, &request, &response, nullptr);
+  if (cntl.Failed()) {
+    LOG(WARNING) << "Fail to send request to : " << cntl.ErrorText();
+    // bthread_usleep(FLAGS_timeout_ms * 1000L);
+  }
+
+  if (FLAGS_log_each_request) {
+    LOG(INFO) << "Received response"
+              << " get_coordinator_map=" << request.cluster_id()
+              << " request_attachment=" << cntl.request_attachment().size()
+              << " response_attachment=" << cntl.response_attachment().size() << " latency=" << cntl.latency_us();
+    LOG(INFO) << response.DebugString();
+  }
+}
+
 void SendGetRegionMap(brpc::Controller& cntl, dingodb::pb::coordinator::CoordinatorService_Stub& stub) {
   dingodb::pb::coordinator::GetRegionMapRequest request;
   dingodb::pb::coordinator::GetRegionMapResponse response;
@@ -247,6 +268,8 @@ void* Sender(void* /*arg*/) {
       SendGetStoreMap(cntl, stub);
     } else if (FLAGS_method == "GetRegionMap") {
       SendGetRegionMap(cntl, stub);
+    } else if (FLAGS_method == "GetCoordinatorMap") {
+      SendGetCoordinatorMap(cntl, stub);
     } else if (FLAGS_method == "GetNodeInfo") {
       SendGetNodeInfo(cntl, node_stub);
     } else {

--- a/src/client/meta_client.cc
+++ b/src/client/meta_client.cc
@@ -122,7 +122,7 @@ void SendGetTable(brpc::Controller& cntl, dingodb::pb::meta::MetaService_Stub& s
   auto* table_id = request.mutable_table_id();
   table_id->set_entity_type(::dingodb::pb::meta::EntityType::ENTITY_TYPE_TABLE);
   table_id->set_parent_entity_id(::dingodb::pb::meta::ReservedSchemaIds::DINGO_SCHEMA);
-  table_id->set_entity_id(102);
+  table_id->set_entity_id(101);
 
   stub.GetTable(&cntl, &request, &response, nullptr);
   if (cntl.Failed()) {

--- a/src/common/helper.cc
+++ b/src/common/helper.cc
@@ -30,6 +30,37 @@ bool Helper::IsIp(const std::string& s) {
   return std::regex_match(s, reg);
 }
 
+int Helper::PeerIdToLocation(braft::PeerId peer_id, pb::common::Location& location) {
+  // parse leader raft location from string
+  auto peer_id_string = peer_id.to_string();
+
+  std::vector<std::string> addrs;
+  butil::SplitString(peer_id_string, ':', &addrs);
+
+  if (addrs.size() != 3) {
+    LOG(ERROR) << "GetLeaderLocation peerid to string error " << peer_id_string;
+    return -1;
+  }
+
+  pb::common::Location temp_location;
+  temp_location.set_host(addrs[0]);
+
+  int32_t value;
+  try {
+    value = std::stoi(addrs[1]);
+    temp_location.set_port(value);
+  } catch (const std::invalid_argument& ia) {
+    LOG(ERROR) << "PeerIdToLocation parse port error Irnvalid argument: " << ia.what() << std::endl;
+    return -1;
+  } catch (const std::out_of_range& oor) {
+    LOG(ERROR) << "PeerIdToLocation parse port error Out of Range error: " << oor.what() << std::endl;
+    return -1;
+  }
+
+  location.CopyFrom(temp_location);
+  return 0;
+}
+
 butil::EndPoint Helper::GetEndPoint(const std::string& host, int port) {
   butil::ip_t ip;
   if (host.empty()) {

--- a/src/common/helper.h
+++ b/src/common/helper.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "braft/configuration.h"
 #include "butil/endpoint.h"
 #include "butil/status.h"
 #include "proto/common.pb.h"
@@ -43,13 +44,17 @@ class Helper {
   // format: 127.0.0.1:8201:0
   static std::string LocationToString(const pb::common::Location& location);
 
+  // transform braft::PeerId to Location
+  // return 0 or -1
+  static int PeerIdToLocation(braft::PeerId peer_id, pb::common::Location& location);
+
   static butil::EndPoint LocationToEndPoint(const pb::common::Location& location);
 
   // format: 127.0.0.1:8201:0,127.0.0.1:8202:0,127.0.0.1:8203:0
   static std::string FormatPeers(const std::vector<pb::common::Location>& locations);
 
   // 127.0.0.1:8201,127.0.0.1:8202,127.0.0.1:8203 to EndPoint
-  static butil::EndPoint StrToEndPoint(const std::string str);
+  static butil::EndPoint StrToEndPoint(std::string str);
   static std::vector<butil::EndPoint> StrToEndpoints(const std::string& str);
 
   static std::shared_ptr<pb::error::Error> Error(pb::error::Errno errcode, const std::string& errmsg);

--- a/src/server/coordinator_service.cc
+++ b/src/server/coordinator_service.cc
@@ -202,6 +202,14 @@ void CoordinatorServiceImpl::GetCoordinatorMap(google::protobuf::RpcController *
   this->coordinator_control_->GetCoordinatorMap(request->cluster_id(), epoch, leader_location, locations);
 
   response->set_epoch(epoch);
+
+  auto *leader_location_resp = response->mutable_leader_location();
+  leader_location_resp->CopyFrom(leader_location);
+
+  for (const auto &member_location : locations) {
+    auto *location = response->add_coordinator_locations();
+    location->CopyFrom(member_location);
+  }
 }
 
 }  // namespace dingodb


### PR DESCRIPTION
[coordinator] Implement GetCoordinatorMap rpc call.

SDK can send GetCoordinatorMap to any one of the coordinators to get the
    leader location, and then connect to the leader coordinator for next rpc
    calls.

[client] Update coordinator and meta client for poc test.